### PR TITLE
Fixes for Faasm build and quick-start

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     steps:
+      - name: "Prune docker"
+        run: docker system prune -f --all
       - name: "Get the code"
         uses: actions/checkout@v2
       - name: "Submodules"

--- a/func/demo/dynlink.cpp
+++ b/func/demo/dynlink.cpp
@@ -33,8 +33,8 @@ int main(int argc, char* argv[])
     printf("mmaped location %p\n", dummyPtr);
 
     // Open both the modules
-    void* handleA = dlopen("lib/libfakeLibA.so", RTLD_NOW);
-    void* handleB = dlopen("lib/libfakeLibB.so", RTLD_NOW);
+    void* handleA = dlopen("lib/fake/libfakeLibA.so", RTLD_NOW);
+    void* handleB = dlopen("lib/fake/libfakeLibB.so", RTLD_NOW);
 
     if (handleA == nullptr || handleB == nullptr) {
         printf("Importing dynamic libs failed\n");

--- a/tasks/libfake.py
+++ b/tasks/libfake.py
@@ -41,9 +41,8 @@ def fake(ctx, clean=False):
     # Copy shared object into place
     sysroot_files = join(WASM_SYSROOT, "lib", "wasm32-wasi", "libfake*.so")
 
-    runtime_lib_dir = join(FAASM_RUNTIME_ROOT, "lib")
-    if not exists(runtime_lib_dir):
-        makedirs(runtime_lib_dir)
+    runtime_lib_dir = join(FAASM_RUNTIME_ROOT, "lib", "fake")
+    makedirs(runtime_lib_dir, exist_ok=True)
 
     run(
         "cp {} {}".format(sysroot_files, runtime_lib_dir),


### PR DESCRIPTION
- Add simple `upload` and `invoke` tasks
- Nest libfake in a directory to allows easier copying with GHA artifacts