### PR TITLE
More robust wtime check

### DIFF
--- a/func/omp/wtime.cpp
+++ b/func/omp/wtime.cpp
@@ -18,12 +18,16 @@ int main(int argc, char* argv[])
 
         usleep(THREAD_SLEEP_MICROS);
 
+        usleep(50 * 1000);
+
         double threadEnd = omp_get_wtime();
 
         threadTime = threadEnd - threadStart;
     }
 
     usleep(MAIN_SLEEP_MICROS);
+
+    usleep(50 * 1000);
 
     double mainEnd = omp_get_wtime();
 


### PR DESCRIPTION
This occasionally failed on a floating point error, so I've made the difference in times more obvious