### PR TITLE
Fix editable pip installs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,9 @@
 from setuptools import setup, find_packages
 from os.path import join, abspath, dirname
 
+import site
+
+site.ENABLE_USER_SITE = True
 
 PROJ_ROOT = dirname(abspath(__file__))
 


### PR DESCRIPTION
We install `faasmtools` as an editable package in faasm's CLI docker image. The installation step was failing, preventing us from building new images.

Use workaround explained [here](https://github.com/pypa/pip/issues/7953).