### PR TITLE
Tiny logging and comment change

### DIFF
--- a/func/omp/repeated_reduce.cpp
+++ b/func/omp/repeated_reduce.cpp
@@ -55,7 +55,7 @@ bool doReduce()
         if (counts[t] != chunkSize) {
             printf(
               "Loop count for thread %i: %i != %i\n", t, counts[t], chunkSize);
-            return false;
+            success = false;
         }
     }
 
@@ -64,15 +64,15 @@ bool doReduce()
 
     if (reducedA != expectedFinalReducedA) {
         printf("reducedA %i != %i\n", reducedA, expectedFinalReducedA);
-        return false;
+        success = false;
     }
 
     if (reducedB != expectedFinalReducedB) {
         printf("reducedB %i != %i\n", reducedB, expectedFinalReducedB);
-        return false;
+        success = false;
     }
 
-    return true;
+    return success;
 }
 
 int main(int argc, char* argv[])

--- a/func/omp/simple_atomic.cpp
+++ b/func/omp/simple_atomic.cpp
@@ -10,9 +10,6 @@ int main()
 
 #pragma omp parallel num_threads(nThreads) default(none) shared(counter)
     {
-        // NOTE - it appears OpenMP doesn't actually support compiling the
-        // atomic pragma to anything useful in wasm, so we have to replace with
-        // our own custom stuff
         FAASM_ATOMIC_INCR_BY(counter, omp_get_thread_num());
     }
 

--- a/libfaasm/faasm/shared_mem.h
+++ b/libfaasm/faasm/shared_mem.h
@@ -46,6 +46,8 @@ extern "C"
     }                                                                          \
     __faasm_sm_critical_local_end();
 
+// It appears OpenMP just ignores the atomic pragma, so we have to replace with
+// our own custom stuff
 #define FAASM_ATOMIC_INCR(var)                                                 \
     __faasm_sm_reduce((void*)&(var), FAASM_TYPE_INT, FAASM_OP_SUM, 1);         \
     FAASM_CRITICAL_LOCAL(var++)


### PR DESCRIPTION
Improve error reporting in `repeated_reduce` and move comment to correct place.