### PR TITLE
Update MPI migrate function

### DIFF
--- a/func/mpi/migrate.cpp
+++ b/func/mpi/migrate.cpp
@@ -1,7 +1,7 @@
+#include "faasm/time.h"
 #include <mpi.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include "faasm/time.h"
 
 #include <faasm/compare.h>
 #include <faasm/faasm.h>
@@ -120,7 +120,8 @@ void doBenchmark(int nLoops)
 int main(int argc, char* argv[])
 {
     if (argc != 3) {
-        printf("Must provide two input arguments: <check_period> <num_loops>\n");
+        printf(
+          "Must provide two input arguments: <check_period> <num_loops>\n");
         return 1;
     }
 
@@ -130,7 +131,7 @@ int main(int argc, char* argv[])
     // support migrating a function twice.
     int checkEveryIn = atoi(argv[1]);
     int numLoopsIn = atoi(argv[2]);
-    int *numLoopsPtr = &numLoops;
+    int* numLoopsPtr = &numLoops;
     *numLoopsPtr = numLoopsIn;
     int* checkEveryPtr = &checkEvery;
     *checkEveryPtr = (int)(numLoops * ((float)checkEveryIn / 10.0));

--- a/func/mpi/migrate.cpp
+++ b/func/mpi/migrate.cpp
@@ -1,4 +1,3 @@
-#include "faasm/time.h"
 #include <mpi.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -6,6 +5,7 @@
 #include <faasm/compare.h>
 #include <faasm/faasm.h>
 #include <faasm/migrate.h>
+#include <faasm/time.h>
 
 int checkEvery = 1;
 int numLoops = 0;
@@ -64,7 +64,6 @@ void doBenchmark(int nLoops)
     MPI_Comm_size(MPI_COMM_WORLD, &worldSize);
 
     // Measure time spent migrating
-    // timespec timeStart{}, timeEnd{};
     double timeStartSec = 0;
     double timeEndSec = 0;
 

--- a/func/mpi/migrate.cpp
+++ b/func/mpi/migrate.cpp
@@ -1,13 +1,14 @@
 #include <mpi.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include "faasm/time.h"
 
 #include <faasm/compare.h>
 #include <faasm/faasm.h>
 #include <faasm/migrate.h>
 
-#define NUM_LOOPS 50000
 int checkEvery = 1;
+int numLoops = 0;
 
 int doAlltoAll(int rank, int worldSize, int i, int nLoops, int checkEvery)
 {
@@ -48,7 +49,7 @@ int doAlltoAll(int rank, int worldSize, int i, int nLoops, int checkEvery)
 // Outer wrapper, and re-entry point after migration
 void doBenchmark(int nLoops)
 {
-    bool mustCheck = nLoops == NUM_LOOPS;
+    bool mustCheck = nLoops == numLoops;
 
     // Initialisation
     int res = MPI_Init(NULL, NULL);
@@ -62,6 +63,14 @@ void doBenchmark(int nLoops)
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &worldSize);
 
+    // Measure time spent migrating
+    // timespec timeStart{}, timeEnd{};
+    double timeStartSec = 0;
+    double timeEndSec = 0;
+
+    // Time point for the migrated ranks
+    printf("Rank %i - time now: %f\n", rank, faasm::getSecondsSinceEpoch());
+
     for (int i = 0; i < nLoops; i++) {
         if (rank == 0 && i % (nLoops / 10) == 0) {
             printf("Starting iteration %i/%i\n", i, nLoops);
@@ -70,6 +79,15 @@ void doBenchmark(int nLoops)
         // Make sure everyone is in sync (including those ranks that have been
         // migrated)
         MPI_Barrier(MPI_COMM_WORLD);
+
+        // Time after migration
+        if (!mustCheck && i % checkEvery == 1 && i / checkEvery > 0) {
+            printf("Time start ms: %f\n", timeStartSec);
+            timeEndSec = faasm::getSecondsSinceEpoch();
+            printf("Rank %i spent %f sec migrating\n",
+                   rank,
+                   timeEndSec - timeStartSec);
+        }
 
         doAlltoAll(rank, worldSize, i, nLoops, checkEvery);
 
@@ -83,6 +101,11 @@ void doBenchmark(int nLoops)
             // benchmark on another host for the remaining iterations.
             // This would eventually be MPI_Barrier
             MPI_Barrier(MPI_COMM_WORLD);
+
+            // Timing
+            timeStartSec = faasm::getSecondsSinceEpoch();
+            printf("Time start ms: %f\n", timeStartSec);
+
             __faasm_migrate_point(&doBenchmark, (nLoops - i - 1));
         }
     }
@@ -96,8 +119,8 @@ void doBenchmark(int nLoops)
 
 int main(int argc, char* argv[])
 {
-    if (argc != 2) {
-        printf("Must provide one input argument: <check_period>\n");
+    if (argc != 3) {
+        printf("Must provide two input arguments: <check_period> <num_loops>\n");
         return 1;
     }
 
@@ -106,13 +129,16 @@ int main(int argc, char* argv[])
     // value as we don't migrate global variables, but that's OK as we don't
     // support migrating a function twice.
     int checkEveryIn = atoi(argv[1]);
+    int numLoopsIn = atoi(argv[2]);
+    int *numLoopsPtr = &numLoops;
+    *numLoopsPtr = numLoopsIn;
     int* checkEveryPtr = &checkEvery;
-    *checkEveryPtr = (int)(NUM_LOOPS * ((float)checkEveryIn / 10.0));
+    *checkEveryPtr = (int)(numLoops * ((float)checkEveryIn / 10.0));
 
     printf(
-      "Starting MPI migration checking at iter %i/%i\n", checkEvery, NUM_LOOPS);
+      "Starting MPI migration checking at iter %i/%i\n", checkEvery, numLoops);
 
-    doBenchmark(NUM_LOOPS);
+    doBenchmark(numLoops);
 
     printf("MPI migration benchmark finished succesfully\n");
 }


### PR DESCRIPTION
Changes:
* Make the number of loops an input parameter and not a constant.
* Measure the time spent migrating for migrated and non-migrated ranks.

The latter measure is informative, so it does not really matter that we measure within WASM.