### PR TITLE
faasmtools: whitelist reference-types and multi-value

### DIFF
--- a/faasmtools/build.py
+++ b/faasmtools/build.py
@@ -255,6 +255,8 @@ def get_faasm_build_env_dict(is_threads=False):
             "relaxed-simd",
             "sign-ext",
             "simd128",
+            "reference-types",
+            "multivalue",
         ]
 
     build_env_dicts["FAASM_WASM_HEADER_INSTALL_DIR"] = join(


### PR DESCRIPTION
This linker features are useful to link against Rust libraries that target `wasm32-wasi`.